### PR TITLE
v0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,9 @@
 ### Fixed 
 - Fixed Firefox and Chrome User-Agent to the latest version
 - Response notes
+
+## [0.0.6] - 2024-01-15
+
+### Fixed
+- Fixed Firefox and Chrome User-Agent to the latest version
+- Context menu shows only cipher suites that matches User-Agent header

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'net.portswigger.burp.extensions'
-version = '0.0.5'
+version = '0.0.6'
 description = 'bypass-bot-detection'
 
 repositories {
@@ -12,10 +12,10 @@ repositories {
 }
 
 dependencies {
-    implementation 'net.portswigger.burp.extensions:montoya-api:2024.7'
+    implementation 'net.portswigger.burp.extensions:montoya-api:2024.12'
     implementation 'com.google.code.gson:gson:2.11.0'
 
-    testImplementation platform('org.junit:junit-bom:5.10.0')
+    testImplementation platform('org.junit:junit-bom:5.10.5')
     testImplementation 'org.junit.jupiter:junit-jupiter'
 }
 

--- a/src/main/java/net/portswigger/burp/extensions/Constants.java
+++ b/src/main/java/net/portswigger/burp/extensions/Constants.java
@@ -32,11 +32,11 @@ public class Constants {
 
     public static Map<String,String> FIREFOX_PLATFORMS = Map.of(
             "Windows",
-            "Windows NT 10.0; Win64; x64; rv:130.0",
+            "Windows NT 10.0; Win64; x64; rv:134.0",
             "Mac",
-            "Macintosh; Intel Mac OS X 14.6; rv:130.0",
+            "Macintosh; Intel Mac OS X 14.7; rv:134.0",
             "Linux",
-            "X11; Linux x86_64; rv:130.0");
+            "X11; Linux x86_64; rv:134.0");
     public static Map<String,String> CHROME_PLATFORMS = Map.of(
             "Windows",
             "Windows NT 10.0; Win64; x64",
@@ -59,9 +59,9 @@ public class Constants {
     );
     // Browsers
     public static Map<String,String> BROWSERS_USER_AGENTS = Map.of(
-            "Firefox", "User-Agent: Mozilla/5.0 (%s) Gecko/20100101 Firefox/129.0",
-            "Chrome", "User-Agent: Mozilla/5.0 (%s) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36",
-            "Safari", "User-Agent: Mozilla/5.0 (%s) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15"
+            "Firefox", "User-Agent: Mozilla/5.0 (%s) Gecko/20100101 Firefox/134.0",
+            "Chrome", "User-Agent: Mozilla/5.0 (%s) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36",
+            "Safari", "User-Agent: Mozilla/5.0 (%s) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.2 Safari/605.1.15"
     );
     public static Map<String,String[]> BROWSERS_PROTOCOLS = Map.of(
             "Firefox", new String[]{"TLSv1.2", "TLSv1.3"},
@@ -157,6 +157,24 @@ public class Constants {
                     "TLS_RSA_WITH_AES_128_CBC_SHA",
                     "TLS_RSA_WITH_AES_256_CBC_SHA",
                     "SSL_RSA_WITH_3DES_EDE_CBC_SHA"},
+            // Chrome ciphers
+            new String[]{"TLSv1.2", "TLSv1.3"},new String[]{
+                    "TLS_AES_128_GCM_SHA256",
+                    "TLS_AES_256_GCM_SHA384",
+                    "TLS_CHACHA20_POLY1305_SHA256",
+                    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+                    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+                    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+                    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+                    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+                    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+                    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+                    "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+                    "TLS_RSA_WITH_AES_128_GCM_SHA256",
+                    "TLS_RSA_WITH_AES_256_GCM_SHA384",
+                    "TLS_RSA_WITH_AES_128_CBC_SHA",
+                    "TLS_RSA_WITH_AES_256_CBC_SHA"
+            },
             // Firefox ciphers
             new String[]{"TLSv1.2", "TLSv1.3"}, new String[]{
                     "TLS_AES_128_GCM_SHA256",

--- a/src/main/java/net/portswigger/burp/extensions/TriggerCipherGuesser.java
+++ b/src/main/java/net/portswigger/burp/extensions/TriggerCipherGuesser.java
@@ -1,6 +1,7 @@
 package net.portswigger.burp.extensions;
 
 import burp.api.montoya.core.Annotations;
+import burp.api.montoya.core.HighlightColor;
 import burp.api.montoya.http.message.HttpRequestResponse;
 import burp.api.montoya.http.message.responses.HttpResponse;
 import net.portswigger.burp.extensions.beens.Browsers;

--- a/src/main/java/net/portswigger/burp/extensions/Utilities.java
+++ b/src/main/java/net/portswigger/burp/extensions/Utilities.java
@@ -159,7 +159,7 @@ public class Utilities {
         } else {
             try {
                 if (doesHostExist(requestResponse.request().url())) {
-                    return montoyaApi.http().sendRequest(requestResponse.withAnnotations(Annotations.annotations(negotiation)).request());
+                    return montoyaApi.http().sendRequest(requestResponse.request()).withAnnotations(Annotations.annotations(negotiation));
                 }
                 return null;
             } catch (Exception e) {

--- a/src/main/resources/strings.properties
+++ b/src/main/resources/strings.properties
@@ -7,3 +7,4 @@ network_preferences=net.portswigger.burp.extensions.bypass.bot.detection
 proxy_preferences=net.portswigger.burp.extensions.bypass.bot.detection.proxy
 loading=Loading custom Settings -> Network -> TLS Negotiation -> Use custom protocols and ciphers. Unload the extension to restore defaults!
 negotiation=Bypass!
+message=Adjust ciphers to common browsers


### PR DESCRIPTION
## [0.0.6] - 2024-01-15

### Fixed
- Fixed Firefox and Chrome User-Agent to the latest version
- Context menu shows only cipher suites that matches User-Agent header